### PR TITLE
Removed daily build

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -3,9 +3,6 @@ on:
   workflow_dispatch: # allows manual triggering
   push:
     branches: [ $default-branch ]
-  #pull_request: # PRs can't work correctly right now
-  schedule: # run every day at midnight
-    - cron: '0 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
This will only break it soon (e.g., when dusk changes the `with levels_upward` syntax). It'll also lead to A LOT of commits. It's easier to trigger it manually in the future. If there's another workshop, we can change it back.